### PR TITLE
colon should not actually be colored, my mistake, sorry

### DIFF
--- a/grammars/cairo.cson
+++ b/grammars/cairo.cson
@@ -186,7 +186,7 @@
         'match': '(:)\\s*([_$[:alpha:]][_$[:alnum:]]+)'
         'captures':
           1:
-            'name': 'keyword.operator'
+            'name': 'punctuation.separator'
           2:
             'name': 'support.type.cairo'
       }
@@ -268,7 +268,7 @@
       }
       {
         'name': 'keyword.operator'
-        'match': '=|!|>|<|\\||&|\\?|:|\\^|~|\\*|\\+|\\-|\\/|\\%'
+        'match': '=|!|>|<|\\||&|\\?|\\^|~|\\*|\\+|\\-|\\/|\\%'
       }
       {
         'match': '(?<![\\w$])(cast)(?![\\w$])'


### PR DESCRIPTION
hey!

I had the same mistake in solidity and vyper grammars but correct is not to color colon when used in most places...

except as part of ternary operator but currently this grammar cannot parse these out so it's ok to not color colons anywhere, looks nicer